### PR TITLE
Avoid empty wave frames with --exp

### DIFF
--- a/lib/cruncher.js
+++ b/lib/cruncher.js
@@ -102,7 +102,7 @@ module.exports = function(wave, note, options) {
           rangeList.push(~~(sample))
           sample = sample + 1
         }
-        samle = (Math.round(Math.pow(cycleLog,cycle*1.1)) * LSDJ.constants.SAMPLES_PER_FRAMES) + (cycle * LSDJ.constants.SAMPLES_PER_FRAMES)
+        samle = (Math.round(Math.pow(cycleLog,cycle*1)) * LSDJ.constants.SAMPLES_PER_FRAMES) + (cycle * LSDJ.constants.SAMPLES_PER_FRAMES)
       }
     }
     


### PR DESCRIPTION
I was getting some empty wave frames at the end of shorter samples using --exp, changing this value helped